### PR TITLE
Adds Taxpayer Identification Number

### DIFF
--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -17,6 +17,7 @@ export default function ImpressumPage() {
             <p><strong>Organization Name:</strong> Klub Društvenih Igara Eliksir</p>
             <p><strong>Legal Form:</strong> Non-Profit Citizens Association</p>
             <p><strong>Registration Number:</strong> 28215096</p>
+            <p><strong>Taxpayer Identification Number:</strong> 109787406</p>
             <p><strong>Registered at:</strong> Serbian Business Registrations Agency</p>
           </div>
         </section>


### PR DESCRIPTION
Adds the Taxpayer Identification Number to the impressum page. This provides users with more complete information about the organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added display of Taxpayer Identification Number (109787406) in the Organization Information section of the Impressum page, improving clarity and legal completeness. This is a content-only update; navigation, layout, and functionality remain unchanged. Users will see an additional paragraph beneath organization details. No settings or actions are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->